### PR TITLE
feat(neuron-ui): vertically fill the Terms Page

### DIFF
--- a/packages/neuron-ui/src/components/Terms/index.tsx
+++ b/packages/neuron-ui/src/components/Terms/index.tsx
@@ -13,6 +13,8 @@ import {
 import { useTranslation } from 'react-i18next'
 import { HAS_READ_TERMS } from 'utils/const'
 
+import styles from './terms.module.scss'
+
 const Terms = ({ setHasReadTerms }: { setHasReadTerms: Function }) => {
   const [t] = useTranslation()
   useEffect(() => {
@@ -40,7 +42,7 @@ const Terms = ({ setHasReadTerms }: { setHasReadTerms: Function }) => {
   const { semanticColors } = getTheme()
 
   return (
-    <div>
+    <Stack verticalFill className={styles.termsContainer}>
       <Label styles={{ root: { color: semanticColors.primaryButtonBackground } }}>{t('terms.intro')}</Label>
       <Pivot linkSize={PivotLinkSize.large}>
         {['for-us-residents', 'for-non-us-residents'].map((type: string) => (
@@ -62,7 +64,7 @@ const Terms = ({ setHasReadTerms }: { setHasReadTerms: Function }) => {
           </PivotItem>
         ))}
       </Pivot>
-    </div>
+    </Stack>
   )
 }
 

--- a/packages/neuron-ui/src/components/Terms/terms.module.scss
+++ b/packages/neuron-ui/src/components/Terms/terms.module.scss
@@ -1,0 +1,31 @@
+.termsContainer {
+  &>div {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+
+    div[role=tabpanel] {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+
+      &>div {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+
+        &>div:first-child {
+          display: flex;
+          flex-direction: column;
+          flex: 1;
+
+          div {
+            display: flex;
+            flex-direction: column;
+            flex: 1
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7271329/67172134-b4a42b00-f3ec-11e9-84da-433cf9751df6.png)
